### PR TITLE
M2 control model code compatible with Rust wrapper

### DIFF
--- a/m2-ctrl/asm/pid-damping/sys/ASM_PIplusD_Fd.c
+++ b/m2-ctrl/asm/pid-damping/sys/ASM_PIplusD_Fd.c
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 10:55:30 2023
+ * C/C++ source code generated on : Fri Apr 14 16:10:20 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)
@@ -18,9 +18,8 @@
 
 /* Model step function */
 void ASM_PIplusD_Fd_step(RT_MODEL_ASM_PIplusD_Fd_T *const ASM_PIplusD_Fd_M,
-  real_T ASM_PIplusD_Fd_U_asm_SP, real_T ASM_PIplusD_Fd_U_asm_FB, real_T
-  ASM_PIplusD_Fd_U_asm_FF, real_T *ASM_PIplusD_Fd_Y_asm_U, real_T
-  *ASM_PIplusD_Fd_Y_asm_Fd)
+  ExtU_ASM_PIplusD_Fd_T *ASM_PIplusD_Fd_U, ExtY_ASM_PIplusD_Fd_T
+  *ASM_PIplusD_Fd_Y)
 {
   DW_ASM_PIplusD_Fd_T *ASM_PIplusD_Fd_DW = ASM_PIplusD_Fd_M->dwork;
   real_T denAccum;
@@ -28,17 +27,13 @@ void ASM_PIplusD_Fd_step(RT_MODEL_ASM_PIplusD_Fd_T *const ASM_PIplusD_Fd_M,
   real_T rtb_Numericaldifferentiation;
 
   /* DiscreteTransferFcn: '<S1>/ASM PI controller' incorporates:
-   *  Inport: '<Root>/asm_FB'
-   *  Inport: '<Root>/asm_SP'
    *  Sum: '<S1>/Sum1'
    */
-  denAccum = (ASM_PIplusD_Fd_U_asm_SP - ASM_PIplusD_Fd_U_asm_FB) -
+  denAccum = (ASM_PIplusD_Fd_U->asm_SP - ASM_PIplusD_Fd_U->asm_FB) -
     (-ASM_PIplusD_Fd_DW->ASMPIcontroller_states);
 
-  /* DiscreteTransferFcn: '<S1>/Numerical differentiation' incorporates:
-   *  Inport: '<Root>/asm_FB'
-   */
-  denAccum_0 = ASM_PIplusD_Fd_U_asm_FB - -0.043213918263772258 *
+  /* DiscreteTransferFcn: '<S1>/Numerical differentiation' */
+  denAccum_0 = ASM_PIplusD_Fd_U->asm_FB - -0.043213918263772258 *
     ASM_PIplusD_Fd_DW->Numericaldifferentiation_states;
   rtb_Numericaldifferentiation = 7654.28865388982 * denAccum_0 +
     -7654.2886538898265 * ASM_PIplusD_Fd_DW->Numericaldifferentiation_states;
@@ -46,18 +41,17 @@ void ASM_PIplusD_Fd_step(RT_MODEL_ASM_PIplusD_Fd_T *const ASM_PIplusD_Fd_M,
   /* Outport: '<Root>/asm_U' incorporates:
    *  DiscreteTransferFcn: '<S1>/ASM PI controller'
    *  Gain: '<S1>/Kd'
-   *  Inport: '<Root>/asm_FF'
    *  Sum: '<S1>/Sum3'
    *  Sum: '<S1>/Sum4'
    */
-  *ASM_PIplusD_Fd_Y_asm_U = ((70031.25 * denAccum + -69968.750000000015 *
+  ASM_PIplusD_Fd_Y->asm_U = ((70031.25 * denAccum + -69968.750000000015 *
     ASM_PIplusD_Fd_DW->ASMPIcontroller_states) - 24.5 *
-    rtb_Numericaldifferentiation) + ASM_PIplusD_Fd_U_asm_FF;
+    rtb_Numericaldifferentiation) + ASM_PIplusD_Fd_U->asm_FF;
 
   /* Outport: '<Root>/asm_Fd' incorporates:
    *  Gain: '<S1>/-Kfdamp'
    */
-  *ASM_PIplusD_Fd_Y_asm_Fd = -9.1 * rtb_Numericaldifferentiation;
+  ASM_PIplusD_Fd_Y->asm_Fd = -9.1 * rtb_Numericaldifferentiation;
 
   /* Update for DiscreteTransferFcn: '<S1>/ASM PI controller' */
   ASM_PIplusD_Fd_DW->ASMPIcontroller_states = denAccum;

--- a/m2-ctrl/asm/pid-damping/sys/ASM_PIplusD_Fd.h
+++ b/m2-ctrl/asm/pid-damping/sys/ASM_PIplusD_Fd.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 10:55:30 2023
+ * C/C++ source code generated on : Fri Apr 14 16:10:20 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)
@@ -29,6 +29,19 @@ typedef struct {
   real_T Numericaldifferentiation_states;/* '<S1>/Numerical differentiation' */
 } DW_ASM_PIplusD_Fd_T;
 
+/* External inputs (root inport signals with default storage) */
+typedef struct {
+  real_T asm_SP;                       /* '<Root>/asm_SP' */
+  real_T asm_FB;                       /* '<Root>/asm_FB' */
+  real_T asm_FF;                       /* '<Root>/asm_FF' */
+} ExtU_ASM_PIplusD_Fd_T;
+
+/* External outputs (root outports fed by signals with default storage) */
+typedef struct {
+  real_T asm_U;                        /* '<Root>/asm_U' */
+  real_T asm_Fd;                       /* '<Root>/asm_Fd' */
+} ExtY_ASM_PIplusD_Fd_T;
+
 /* Real-time Model Data Structure */
 struct tag_RTM_ASM_PIplusD_Fd_T {
   DW_ASM_PIplusD_Fd_T *dwork;
@@ -38,9 +51,8 @@ struct tag_RTM_ASM_PIplusD_Fd_T {
 extern void ASM_PIplusD_Fd_initialize(RT_MODEL_ASM_PIplusD_Fd_T *const
   ASM_PIplusD_Fd_M);
 extern void ASM_PIplusD_Fd_step(RT_MODEL_ASM_PIplusD_Fd_T *const
-  ASM_PIplusD_Fd_M, real_T ASM_PIplusD_Fd_U_asm_SP, real_T
-  ASM_PIplusD_Fd_U_asm_FB, real_T ASM_PIplusD_Fd_U_asm_FF, real_T
-  *ASM_PIplusD_Fd_Y_asm_U, real_T *ASM_PIplusD_Fd_Y_asm_Fd);
+  ASM_PIplusD_Fd_M, ExtU_ASM_PIplusD_Fd_T *ASM_PIplusD_Fd_U,
+  ExtY_ASM_PIplusD_Fd_T *ASM_PIplusD_Fd_Y);
 extern void ASM_PIplusD_Fd_terminate(RT_MODEL_ASM_PIplusD_Fd_T *const
   ASM_PIplusD_Fd_M);
 

--- a/m2-ctrl/asm/pid-damping/sys/ASM_PIplusD_Fd_private.h
+++ b/m2-ctrl/asm/pid-damping/sys/ASM_PIplusD_Fd_private.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 10:55:30 2023
+ * C/C++ source code generated on : Fri Apr 14 16:10:20 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)

--- a/m2-ctrl/asm/pid-damping/sys/ASM_PIplusD_Fd_types.h
+++ b/m2-ctrl/asm/pid-damping/sys/ASM_PIplusD_Fd_types.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 10:55:30 2023
+ * C/C++ source code generated on : Fri Apr 14 16:10:20 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)

--- a/m2-ctrl/asm/pid-damping/sys/rt_defines.h
+++ b/m2-ctrl/asm/pid-damping/sys/rt_defines.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 10:55:30 2023
+ * C/C++ source code generated on : Fri Apr 14 16:10:20 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)

--- a/m2-ctrl/asm/pid-damping/sys/rtwtypes.h
+++ b/m2-ctrl/asm/pid-damping/sys/rtwtypes.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 10:55:30 2023
+ * C/C++ source code generated on : Fri Apr 14 16:10:20 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)

--- a/m2-ctrl/asm/positionner/sys/M2P_act_Cfb.c
+++ b/m2-ctrl/asm/positionner/sys/M2P_act_Cfb.c
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 11:04:05 2023
+ * C/C++ source code generated on : Fri Apr 14 16:12:21 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)
@@ -17,8 +17,9 @@
 #include "rtwtypes.h"
 
 /* Model step function */
-void M2P_act_Cfb_step(RT_MODEL_M2P_act_Cfb_T *const M2P_act_Cfb_M, real_T
-                      M2P_act_Cfb_U_M2pAct_E, real_T *M2P_act_Cfb_Y_M2pAct_U)
+void M2P_act_Cfb_step(RT_MODEL_M2P_act_Cfb_T *const M2P_act_Cfb_M,
+                      ExtU_M2P_act_Cfb_T *M2P_act_Cfb_U, ExtY_M2P_act_Cfb_T
+                      *M2P_act_Cfb_Y)
 {
   DW_M2P_act_Cfb_T *M2P_act_Cfb_DW = M2P_act_Cfb_M->dwork;
   real_T M2P_I_rolloffF_tmp;
@@ -26,9 +27,8 @@ void M2P_act_Cfb_step(RT_MODEL_M2P_act_Cfb_T *const M2P_act_Cfb_M, real_T
   /* DiscreteTransferFcn: '<S1>/M2P_I_rolloffF' incorporates:
    *  Gain: '<S1>/k2p_stiff'
    *  Gain: '<S1>/m2p_om_c'
-   *  Inport: '<Root>/M2pAct_E'
    */
-  M2P_I_rolloffF_tmp = ((1.479910125477238E+8 * M2P_act_Cfb_U_M2pAct_E *
+  M2P_I_rolloffF_tmp = ((1.479910125477238E+8 * M2P_act_Cfb_U->M2pAct_E *
     12.566370614359172 - -2.9921153371845048 *
     M2P_act_Cfb_DW->M2P_I_rolloffF_states[0]) - 2.9842921174770662 *
                         M2P_act_Cfb_DW->M2P_I_rolloffF_states[1]) -
@@ -37,7 +37,7 @@ void M2P_act_Cfb_step(RT_MODEL_M2P_act_Cfb_T *const M2P_act_Cfb_M, real_T
   /* Outport: '<Root>/M2pAct_U' incorporates:
    *  DiscreteTransferFcn: '<S1>/M2P_I_rolloffF'
    */
-  *M2P_act_Cfb_Y_M2pAct_U = ((3.2077152625295559E-10 * M2P_I_rolloffF_tmp +
+  M2P_act_Cfb_Y->M2pAct_U = ((3.2077152625295559E-10 * M2P_I_rolloffF_tmp +
     3.5229414952692262E-9 * M2P_act_Cfb_DW->M2P_I_rolloffF_states[0]) +
     3.5174120042123771E-9 * M2P_act_Cfb_DW->M2P_I_rolloffF_states[1]) +
     3.192634813656456E-10 * M2P_act_Cfb_DW->M2P_I_rolloffF_states[2];

--- a/m2-ctrl/asm/positionner/sys/M2P_act_Cfb.h
+++ b/m2-ctrl/asm/positionner/sys/M2P_act_Cfb.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 11:04:05 2023
+ * C/C++ source code generated on : Fri Apr 14 16:12:21 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)
@@ -28,6 +28,16 @@ typedef struct {
   real_T M2P_I_rolloffF_states[3];     /* '<S1>/M2P_I_rolloffF' */
 } DW_M2P_act_Cfb_T;
 
+/* External inputs (root inport signals with default storage) */
+typedef struct {
+  real_T M2pAct_E;                     /* '<Root>/M2pAct_E' */
+} ExtU_M2P_act_Cfb_T;
+
+/* External outputs (root outports fed by signals with default storage) */
+typedef struct {
+  real_T M2pAct_U;                     /* '<Root>/M2pAct_U' */
+} ExtY_M2P_act_Cfb_T;
+
 /* Real-time Model Data Structure */
 struct tag_RTM_M2P_act_Cfb_T {
   DW_M2P_act_Cfb_T *dwork;
@@ -35,8 +45,8 @@ struct tag_RTM_M2P_act_Cfb_T {
 
 /* Model entry point functions */
 extern void M2P_act_Cfb_initialize(RT_MODEL_M2P_act_Cfb_T *const M2P_act_Cfb_M);
-extern void M2P_act_Cfb_step(RT_MODEL_M2P_act_Cfb_T *const M2P_act_Cfb_M, real_T
-  M2P_act_Cfb_U_M2pAct_E, real_T *M2P_act_Cfb_Y_M2pAct_U);
+extern void M2P_act_Cfb_step(RT_MODEL_M2P_act_Cfb_T *const M2P_act_Cfb_M,
+  ExtU_M2P_act_Cfb_T *M2P_act_Cfb_U, ExtY_M2P_act_Cfb_T *M2P_act_Cfb_Y);
 extern void M2P_act_Cfb_terminate(RT_MODEL_M2P_act_Cfb_T *const M2P_act_Cfb_M);
 
 /*-

--- a/m2-ctrl/asm/positionner/sys/M2P_act_Cfb_private.h
+++ b/m2-ctrl/asm/positionner/sys/M2P_act_Cfb_private.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 11:04:05 2023
+ * C/C++ source code generated on : Fri Apr 14 16:12:21 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)

--- a/m2-ctrl/asm/positionner/sys/M2P_act_Cfb_types.h
+++ b/m2-ctrl/asm/positionner/sys/M2P_act_Cfb_types.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 11:04:05 2023
+ * C/C++ source code generated on : Fri Apr 14 16:12:21 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)

--- a/m2-ctrl/asm/positionner/sys/rt_defines.h
+++ b/m2-ctrl/asm/positionner/sys/rt_defines.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 11:04:05 2023
+ * C/C++ source code generated on : Fri Apr 14 16:12:21 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)

--- a/m2-ctrl/asm/positionner/sys/rtwtypes.h
+++ b/m2-ctrl/asm/positionner/sys/rtwtypes.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 11:04:05 2023
+ * C/C++ source code generated on : Fri Apr 14 16:12:21 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)

--- a/m2-ctrl/asm/preshape-filter/sys/ASM_preshapeBesselF.c
+++ b/m2-ctrl/asm/preshape-filter/sys/ASM_preshapeBesselF.c
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 10:34:30 2023
+ * C/C++ source code generated on : Fri Apr 14 16:03:45 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)
@@ -18,9 +18,8 @@
 
 /* Model step function */
 void ASM_preshapeBesselF_step(RT_MODEL_ASM_preshapeBesselF_T *const
-  ASM_preshapeBesselF_M, real_T ASM_preshapeBesselF_U_AO_cmd, real_T
-  *ASM_preshapeBesselF_Y_cmd_f_ddot, real_T *ASM_preshapeBesselF_Y_cmd_f_dot,
-  real_T *ASM_preshapeBesselF_Y_cmd_f)
+  ASM_preshapeBesselF_M, ExtU_ASM_preshapeBesselF_T *ASM_preshapeBesselF_U,
+  ExtY_ASM_preshapeBesselF_T *ASM_preshapeBesselF_Y)
 {
   DW_ASM_preshapeBesselF_T *ASM_preshapeBesselF_DW =
     ASM_preshapeBesselF_M->dwork;
@@ -28,55 +27,51 @@ void ASM_preshapeBesselF_step(RT_MODEL_ASM_preshapeBesselF_T *const
   /* local block i/o variables */
   real_T rtb_SSflag_d[3];
 
-  /* DiscreteStateSpace: '<S1>/SS flag_d' incorporates:
-   *  Inport: '<Root>/AO_cmd'
-   */
+  /* DiscreteStateSpace: '<S1>/SS flag_d' */
   {
     rtb_SSflag_d[0] = (64.854543862967589)*
       ASM_preshapeBesselF_DW->SSflag_d_DSTATE[3];
-    rtb_SSflag_d[0] += (0.02967202116338219)*ASM_preshapeBesselF_U_AO_cmd;
+    rtb_SSflag_d[0] += (0.02967202116338219)*ASM_preshapeBesselF_U->AO_cmd;
     rtb_SSflag_d[1] = (531288.42332543049)*
       ASM_preshapeBesselF_DW->SSflag_d_DSTATE[2];
-    rtb_SSflag_d[1] += (966.12498421264081)*ASM_preshapeBesselF_U_AO_cmd;
+    rtb_SSflag_d[1] += (966.12498421264081)*ASM_preshapeBesselF_U->AO_cmd;
     rtb_SSflag_d[2] = (8.7046295277638531E+9)*
       ASM_preshapeBesselF_DW->SSflag_d_DSTATE[1];
-    rtb_SSflag_d[2] += (2.193858624795932E+7)*ASM_preshapeBesselF_U_AO_cmd;
+    rtb_SSflag_d[2] += (2.193858624795932E+7)*ASM_preshapeBesselF_U->AO_cmd;
   }
 
   /* Outport: '<Root>/cmd_f_ddot' */
-  *ASM_preshapeBesselF_Y_cmd_f_ddot = rtb_SSflag_d[2];
+  ASM_preshapeBesselF_Y->cmd_f_ddot = rtb_SSflag_d[2];
 
   /* Outport: '<Root>/cmd_f_dot' */
-  *ASM_preshapeBesselF_Y_cmd_f_dot = rtb_SSflag_d[1];
+  ASM_preshapeBesselF_Y->cmd_f_dot = rtb_SSflag_d[1];
 
   /* Outport: '<Root>/cmd_f' */
-  *ASM_preshapeBesselF_Y_cmd_f = rtb_SSflag_d[0];
+  ASM_preshapeBesselF_Y->cmd_f = rtb_SSflag_d[0];
 
-  /* Update for DiscreteStateSpace: '<S1>/SS flag_d' incorporates:
-   *  Inport: '<Root>/AO_cmd'
-   */
+  /* Update for DiscreteStateSpace: '<S1>/SS flag_d' */
   {
     real_T xnew[4];
     xnew[0] = (-0.19681414194734359)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[0]
       + (-0.14259315154461696)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[1]
       + (0.040453300816057164)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[2]
       + (0.051638401896805804)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[3];
-    xnew[0] += (-0.0020947948356031219)*ASM_preshapeBesselF_U_AO_cmd;
+    xnew[0] += (-0.0020947948356031219)*ASM_preshapeBesselF_U->AO_cmd;
     xnew[1] = (-0.20383199230440782)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[0]
       + (-0.46542752046735508)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[1]
       + (-0.60377138667380037)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[2]
       + (-0.23003467850294718)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[3];
-    xnew[1] += (-0.0015261217100169221)*ASM_preshapeBesselF_U_AO_cmd;
+    xnew[1] += (-0.0015261217100169221)*ASM_preshapeBesselF_U->AO_cmd;
     xnew[2] = (0.45400733849259595)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[0]
       + (0.4963828463732019)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[1]
       + (0.24417632653651067)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[2]
       + (-0.33475625988707469)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[3];
-    xnew[2] += (0.005278256919681569)*ASM_preshapeBesselF_U_AO_cmd;
+    xnew[2] += (0.005278256919681569)*ASM_preshapeBesselF_U->AO_cmd;
     xnew[3] = (0.33034540614518554)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[0]
       + (0.5488368113362464)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[1]
       + (0.7645142910481324)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[2]
       + (0.87923437697342)*ASM_preshapeBesselF_DW->SSflag_d_DSTATE[3];
-    xnew[3] += (0.0048663990653113253)*ASM_preshapeBesselF_U_AO_cmd;
+    xnew[3] += (0.0048663990653113253)*ASM_preshapeBesselF_U->AO_cmd;
     (void) memcpy(&ASM_preshapeBesselF_DW->SSflag_d_DSTATE[0], xnew,
                   sizeof(real_T)*4);
   }

--- a/m2-ctrl/asm/preshape-filter/sys/ASM_preshapeBesselF.h
+++ b/m2-ctrl/asm/preshape-filter/sys/ASM_preshapeBesselF.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 10:34:30 2023
+ * C/C++ source code generated on : Fri Apr 14 16:03:45 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)
@@ -29,6 +29,18 @@ typedef struct {
   real_T SSflag_d_DSTATE[4];           /* '<S1>/SS flag_d' */
 } DW_ASM_preshapeBesselF_T;
 
+/* External inputs (root inport signals with default storage) */
+typedef struct {
+  real_T AO_cmd;                       /* '<Root>/AO_cmd' */
+} ExtU_ASM_preshapeBesselF_T;
+
+/* External outputs (root outports fed by signals with default storage) */
+typedef struct {
+  real_T cmd_f_ddot;                   /* '<Root>/cmd_f_ddot' */
+  real_T cmd_f_dot;                    /* '<Root>/cmd_f_dot' */
+  real_T cmd_f;                        /* '<Root>/cmd_f' */
+} ExtY_ASM_preshapeBesselF_T;
+
 /* Real-time Model Data Structure */
 struct tag_RTM_ASM_preshapeBesselF_T {
   DW_ASM_preshapeBesselF_T *dwork;
@@ -38,9 +50,8 @@ struct tag_RTM_ASM_preshapeBesselF_T {
 extern void ASM_preshapeBesselF_initialize(RT_MODEL_ASM_preshapeBesselF_T *const
   ASM_preshapeBesselF_M);
 extern void ASM_preshapeBesselF_step(RT_MODEL_ASM_preshapeBesselF_T *const
-  ASM_preshapeBesselF_M, real_T ASM_preshapeBesselF_U_AO_cmd, real_T
-  *ASM_preshapeBesselF_Y_cmd_f_ddot, real_T *ASM_preshapeBesselF_Y_cmd_f_dot,
-  real_T *ASM_preshapeBesselF_Y_cmd_f);
+  ASM_preshapeBesselF_M, ExtU_ASM_preshapeBesselF_T *ASM_preshapeBesselF_U,
+  ExtY_ASM_preshapeBesselF_T *ASM_preshapeBesselF_Y);
 extern void ASM_preshapeBesselF_terminate(RT_MODEL_ASM_preshapeBesselF_T *const
   ASM_preshapeBesselF_M);
 

--- a/m2-ctrl/asm/preshape-filter/sys/ASM_preshapeBesselF_private.h
+++ b/m2-ctrl/asm/preshape-filter/sys/ASM_preshapeBesselF_private.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 10:34:30 2023
+ * C/C++ source code generated on : Fri Apr 14 16:03:45 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)

--- a/m2-ctrl/asm/preshape-filter/sys/ASM_preshapeBesselF_types.h
+++ b/m2-ctrl/asm/preshape-filter/sys/ASM_preshapeBesselF_types.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 10:34:30 2023
+ * C/C++ source code generated on : Fri Apr 14 16:03:45 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)

--- a/m2-ctrl/asm/preshape-filter/sys/rt_defines.h
+++ b/m2-ctrl/asm/preshape-filter/sys/rt_defines.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 10:34:30 2023
+ * C/C++ source code generated on : Fri Apr 14 16:03:45 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)

--- a/m2-ctrl/asm/preshape-filter/sys/rtwtypes.h
+++ b/m2-ctrl/asm/preshape-filter/sys/rtwtypes.h
@@ -5,7 +5,7 @@
  *
  * Model version                  : 9.4
  * Simulink Coder version         : 9.8 (R2022b) 13-May-2022
- * C/C++ source code generated on : Thu Apr 13 10:34:30 2023
+ * C/C++ source code generated on : Fri Apr 14 16:03:45 2023
  *
  * Target selection: ert.tlc
  * Embedded hardware selection: Intel->x86-64 (Linux 64)


### PR DESCRIPTION
M2 control model code with `RootIOFormat` set to `Structure reference`.